### PR TITLE
only require pylint < 2.0 for Python 2.x

### DIFF
--- a/lib/vsc/install/shared_setup.py
+++ b/lib/vsc/install/shared_setup.py
@@ -1382,7 +1382,10 @@ class vsc_setup(object):
         else:
             log.info('adding prospector to tests_require')
             tests_requires = new_target.setdefault('tests_require', [])
-            tests_requires.extend(['prospector >= 1.1.4', 'pylint<2.0.0'])
+            tests_requires.append('prospector >= 1.1.4')
+            # Python 2.x requires pylint < 2.0, since pylint 2.0 or newer is Python 3 only
+            if sys.version_info < (2,):
+                tests_requires.append('pylint<2.0.0')
             new_target['tests_require'] = tests_requires
 
         if self.private_repo:


### PR DESCRIPTION
@wdpypere fix for Python 3 test failures in https://github.com/hpcugent/vsc-install/pull/90, see https://travis-ci.org/boegel/vsc-install/builds/450762907